### PR TITLE
docs: clarify feed operator compatibility and integration boundaries

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development Guide
 
-Quick start guide for local development of the DP-1 Feed API.
+Quick start guide for developing and operating the open-source DP-1 feed operator API in this repository.
+
+Canonical protocol versioning is defined in `display-protocol/dp1` (currently v1.1.0). This codebase keeps explicit compatibility with implemented 1.0.x request patterns and documented legacy aliases.
 
 ## Prerequisites
 
@@ -9,6 +11,8 @@ Quick start guide for local development of the DP-1 Feed API.
 - **Node.js**: Docker (recommended) or etcd + NATS JetStream
 
 ## Quick Start
+
+The quickest local path in this repo is Node.js with Docker Compose. Cloudflare Workers is also supported.
 
 ### Cloudflare Workers
 
@@ -36,6 +40,19 @@ docker compose down
 ```
 
 Server runs at `http://localhost:8787`
+
+First-run verification (after either path is up):
+
+```bash
+curl http://localhost:8787/api/v1/health
+
+curl -X POST http://localhost:8787/api/v1/playlists \
+  -H "Authorization: Bearer dev-api-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"dpVersion":"1.0.0","title":"minimal-playlist","items":[{"source":"https://example.com/artwork.html","duration":300,"license":"open"}]}'
+```
+
+Write operations require `Authorization: Bearer <API_SECRET or JWT>`.
 
 ### Node.js (Local Development)
 

--- a/README.md
+++ b/README.md
@@ -5,51 +5,98 @@
 [![Code Coverage](https://img.shields.io/codecov/c/github/feral-file/dp1-feed/main?label=code%20coverage&logo=codecov)](https://codecov.io/gh/feral-file/dp1-feed)
 [![Benchmark](https://img.shields.io/github/actions/workflow/status/feral-file/dp1-feed/benchmark.yaml?branch=main&label=benchmark%20status&logo=github)](https://github.com/feral-file/dp1-feed/actions/workflows/benchmark.yaml)
 
-A REST API server implementing the [DP-1 specification](https://github.com/display-protocol/dp1/blob/main/docs/spec.md) for managing blockchain-native digital art playlists. Deploy as serverless (Cloudflare Workers) or self-hosted (Node.js).
+Open-source reference implementation of a DP-1 feed operator API.
 
-## Features
+- It implements operator-side API behavior for creating, signing, storing, and serving playlists/channels.
+- It is not the same thing as Feral File's hosted production feed service.
+- It can run in two deployment modes: Cloudflare Workers or self-hosted Node.js.
 
-- **DP-1 v1.1.0 Compliant** - Full OpenAPI 3.1.0 implementation
-- **Dual Deployment** - Cloudflare Workers (serverless) or Node.js (self-hosted)
-- **Type-Safe** - TypeScript with Zod validation
-- **Production Ready** - Ed25519 signatures, JWT auth, async processing (RFC 7240)
+## Canonical Entry Points
 
-## Quick Start
+- `openapi.yaml` - API surface and request/response contracts in this repo.
+- [display-protocol/dp1](https://github.com/display-protocol/dp1) - canonical DP-1 protocol spec source.
+- [docs.feralfile.com](https://docs.feralfile.com) - guided integration and operator usage paths.
 
-### Prerequisites
+## Compatibility Note (Current, Legacy, Transitional, Unverified)
+
+The DP-1 protocol and ecosystem are in a transition period. This repo intentionally states compatibility status plainly.
+
+| Status                | Meaning in this repo                                                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Canonical**         | DP-1 spec canonical source is `display-protocol/dp1` and currently states **v1.1.0**.                                                                                                                   |
+| **Current here**      | This operator API, `openapi.yaml`, and first-run examples are centered on the currently implemented API behavior in this repo. In request examples, `dpVersion: "1.0.0"` remains the explicit baseline. |
+| **Legacy-compatible** | Legacy naming still accepted where documented (for example `playlist-group` query compatibility and `/api/v1/playlist-groups` endpoint).                                                                |
+| **Transitional**      | Some adjacent tools/examples in the wider ecosystem still center 1.0.x conventions. This repo keeps those paths visible where they are actively implemented.                                            |
+| **Unverified**        | End-to-end parity claims for all DP-1 v1.1.0 semantics are **not** made here unless specifically validated in this repo.                                                                                |
+
+If protocol truth and this implementation diverge, protocol truth lives in `display-protocol/dp1`, and implementation notes should be updated here with explicit status.
+
+## Deployment Choices
+
+### Option A: Self-hosted Node.js (quickest local path)
+
+This is the most direct local operator quickstart in this repo because `docker-compose.yml` and `.env.sample` already provide runnable defaults.
+
+Prerequisites:
 
 - Node.js 22+
-- **Cloudflare Workers**: Cloudflare account + Wrangler CLI
-- **Node.js**: Docker or etcd + NATS JetStream
+- Docker + Docker Compose
 
-### Installation
+Run:
 
 ```bash
-git clone https://github.com/feral-file/dp1-feed.git
-cd dp1-feed
 npm install
+docker compose up -d
 ```
 
-### Deploy
+The API is served at `http://localhost:8787`.
 
-**Cloudflare Workers (Serverless)**
+### Option B: Cloudflare Workers
+
+Prerequisites:
+
+- Node.js 22+
+- Wrangler CLI
+- Cloudflare account
+- KV namespaces and queue setup
+- required secrets: `API_SECRET`, `ED25519_PRIVATE_KEY` (and optionally JWT settings)
+
+Run:
 
 ```bash
-# Setup and deploy
+npm install
 npm run worker:setup:kv
 npm run worker:setup:r2
 npm run worker:setup:secrets
-npm run worker:deploy
+npm run worker:setup:queues:dev
+npm run worker:dev
 ```
 
-**Node.js (Self-Hosted)**
+## First Run: Build Trust in 3 Calls
+
+Write operations require auth (`Authorization: Bearer <API_SECRET or JWT>`). Read operations are public.
 
 ```bash
-# Option 1: Docker Compose (recommended)
-docker compose up -d
+# 1) Health check (no auth)
+curl http://localhost:8787/api/v1/health
+# 2) Create a minimal playlist (auth required)
+curl -X POST http://localhost:8787/api/v1/playlists \
+  -H "Authorization: Bearer dev-api-secret" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dpVersion": "1.0.0",
+    "title": "minimal-playlist",
+    "items": [
+      {
+        "source": "https://example.com/artwork.html",
+        "duration": 300,
+        "license": "open"
+      }
+    ]
+  }'
 
-# Option 2: Local development
-npm run node:dev
+# 3) Fetch it back (replace <playlist-id-or-slug>)
+curl http://localhost:8787/api/v1/playlists/<playlist-id-or-slug>
 ```
 
 Server runs on `http://localhost:8787` by default.
@@ -107,32 +154,21 @@ Generate test keys: `npm run jwt:generate-keys`
 
 **Create Playlist**
 
-```bash
-curl -X POST http://localhost:8787/api/v1/playlists \
-  -H "Authorization: Bearer YOUR_API_SECRET" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "dpVersion": "1.0.0",
-    "title": "my-playlist",
-    "items": [{
-      "source": "https://example.com/art.html",
-      "duration": 300,
-      "license": "open"
-    }]
-  }'
-```
+````bash
 
-**List Playlists**
+## Operator Responsibilities in This Repo
 
-```bash
-curl "http://localhost:8787/api/v1/playlists?sort=desc&limit=10"
-```
+- Deploy runtime (`worker.ts` or `server.ts` path).
+- Configure secrets/auth (`API_SECRET`, `ED25519_PRIVATE_KEY`, optional JWT settings).
+- Accept and validate DP-1 payloads (`openapi.yaml` + Zod/ff-dp1-js validation paths).
+- Sign playlists/channels server-side with Ed25519 before persistence.
+- Serve read APIs and write APIs (sync by default, optional `Prefer: respond-async`).
 
 **Get Curated Registry**
 
 ```bash
 curl "http://localhost:8787/api/v1/registry/channels"
-```
+````
 
 **Update Curated Registry**
 
@@ -152,54 +188,29 @@ curl -X PUT http://localhost:8787/api/v1/registry/channels \
 
 ### Async Processing
 
-Add `Prefer: respond-async` header for background processing:
+## Hosted vs Run-Your-Own References
 
-```bash
-curl -X POST http://localhost:8787/api/v1/playlists \
-  -H "Authorization: Bearer YOUR_API_SECRET" \
-  -H "Prefer: respond-async" \
-  -H "Content-Type: application/json" \
-  -d '{...}'
-```
+- Hosted Feral feed usage guidance: use `docs.feralfile.com`.
+- Run-your-own operator behavior and deployment: this repository.
 
-- **Synchronous** (default): Returns `201` after data is persisted
-- **Asynchronous**: Returns `202` immediately, queues for background processing
+## API Surface
 
-## Development
+See `openapi.yaml` for complete endpoint definitions and schemas.
 
-```bash
-# Cloudflare Workers
-npm run worker:dev
+Key routes:
 
-# Node.js
-npm run node:dev
+- `GET /api/v1`, `GET /api/v1/health`
+- `GET/POST /api/v1/playlists`, `GET/PUT/PATCH/DELETE /api/v1/playlists/{id}`
+- `GET/POST /api/v1/channels`, `GET/PUT/PATCH/DELETE /api/v1/channels/{id}`
+- `GET /api/v1/playlist-items`, `GET /api/v1/playlist-items/{id}`
+- Legacy compatibility: `GET /api/v1/playlist-groups`
+- Self-hosted queue processing endpoints: `/queues/process-message`, `/queues/process-batch`
 
-# Tests
-npm test
-npm run test:api         # Integration tests
-npm run benchmark        # Performance tests
+## Development and Testing
 
-# Code quality
-npm run validate         # Run all checks
-```
-
-See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed setup and [TESTING.md](TESTING.md) for testing guide.
-
-## Documentation
-
-- **[DEVELOPMENT.md](DEVELOPMENT.md)** - Setup, configuration, and project structure
-- **[TESTING.md](TESTING.md)** - Testing strategies and benchmarking
-- **[OpenAPI Spec](openapi.yaml)** - Full API specification
-- **[DP-1 Specification](https://github.com/display-protocol/dp1/blob/main/docs/spec.md)** - Protocol documentation
-
-## Contributing
-
-1. Fork the repository
-2. Create feature branch (`git checkout -b feature/amazing-feature`)
-3. Write tests and ensure they pass (`npm run validate`)
-4. Commit changes (`git commit -m 'Add amazing feature'`)
-5. Push to branch (`git push origin feature/amazing-feature`)
-6. Open a Pull Request
+- Development setup: [DEVELOPMENT.md](DEVELOPMENT.md)
+- Testing and benchmarks: [TESTING.md](TESTING.md)
+- Protocol spec source: [display-protocol/dp1](https://github.com/display-protocol/dp1/blob/main/docs/spec.md)
 
 ## License
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,8 @@
 
 Comprehensive testing guide for the DP-1 Feed API covering unit tests, integration tests, and performance benchmarks.
 
+These tests validate implemented operator behavior in this repository; they should not be read as blanket proof of full end-to-end DP-1 v1.1.0 parity across the wider ecosystem.
+
 ## Quick Start
 
 ```bash

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,9 +3,13 @@ info:
   title: DP-1 Feed Operator API
   version: 1.1.0
   description: |
-    REST interface for creating, updating, and retrieving DP-1 playlists and channels.
+    Open-source reference feed operator interface for creating, updating, and retrieving DP-1 playlists and channels.
 
-    This API implements the DP-1 (Display Protocol v1) specification for managing digital content playlists and channels.
+    This repository is an operator implementation, not a managed hosted service definition.
+
+    Canonical DP-1 protocol truth is maintained in display-protocol/dp1 (currently v1.1.0).
+    This implementation keeps explicit compatibility with actively implemented 1.0.x-style request examples
+    and legacy endpoint/query aliases where noted in this OpenAPI document.
 
     ## Authentication
 
@@ -34,10 +38,10 @@ info:
     name: MIT
     url: https://opensource.org/licenses/MIT
 servers:
-  - url: https://feed.feralfile.com
-    description: Production server
   - url: http://localhost:8787
-    description: Local development server
+    description: Local operator instance (self-hosted or wrangler dev)
+  - url: https://example-dp1-feed.your-domain.tld
+    description: Example deployed operator base URL
 
 security:
   - ApiKeyAuth: []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dp1-feed-operator-api",
   "version": "1.0.0",
-  "description": "DP-1 Feed Operator API Server - OpenAPI 3.1.0 compliant server for managing blockchain-native digital art playlists and exhibitions",
+  "description": "Open-source reference DP-1 feed operator API for Cloudflare Workers and self-hosted Node.js deployments",
   "main": "./worker.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- reframe README around operator responsibilities, canonical entry points, and compatibility status (current/legacy/transitional/unverified)
- tighten first-run trust checks and deployment choices for self-hosted and worker modes
- update supporting docs/OpenAPI references to match the new positioning and terminology

## Notes
- this keeps the feed operator repo focused on run-your-own behavior
- hosted Feral feed guidance remains in docs.feralfile.com